### PR TITLE
Add create heating system endpoint

### DIFF
--- a/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/controller/HeatingSystemController.java
+++ b/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/controller/HeatingSystemController.java
@@ -24,6 +24,13 @@ public class HeatingSystemController {
 
     private static final Logger logger = LoggerFactory.getLogger(HeatingSystemController.class);
 
+    @PostMapping
+    public ResponseEntity<HeatingSystemDto> createHeatingSystem(@RequestBody HeatingSystemDto heatingSystemDto) {
+        logger.info("Creating new heating system");
+        HeatingSystemDto createdHeatingSystem = heatingSystemService.createHeatingSystem(heatingSystemDto);
+        return ResponseEntity.ok(createdHeatingSystem);
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<HeatingSystemDto> getHeatingSystem(@PathVariable("id") Long id) {
         logger.info("Fetching heating system with id {}", id);

--- a/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/service/HeatingSystemService.java
+++ b/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/service/HeatingSystemService.java
@@ -4,6 +4,7 @@ import ru.yandex.practicum.smarthome.dto.HeatingSystemDto;
 import ru.yandex.practicum.smarthome.entity.HeatingSystem;
 
 public interface HeatingSystemService {
+    HeatingSystemDto createHeatingSystem(HeatingSystemDto heatingSystemDto);
     HeatingSystemDto getHeatingSystem(Long id);
     HeatingSystemDto updateHeatingSystem(Long id, HeatingSystemDto heatingSystemDto);
     void turnOn(Long id);

--- a/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/service/HeatingSystemServiceImpl.java
+++ b/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/service/HeatingSystemServiceImpl.java
@@ -10,7 +10,17 @@ import ru.yandex.practicum.smarthome.repository.HeatingSystemRepository;
 @RequiredArgsConstructor
 public class HeatingSystemServiceImpl implements HeatingSystemService {
     private final HeatingSystemRepository heatingSystemRepository;
-    
+
+    @Override
+    public HeatingSystemDto createHeatingSystem(HeatingSystemDto heatingSystemDto) {
+        HeatingSystem heatingSystem = new HeatingSystem();
+        heatingSystem.setOn(heatingSystemDto.isOn());
+        heatingSystem.setTargetTemperature(heatingSystemDto.getTargetTemperature());
+        heatingSystem.setCurrentTemperature(heatingSystemDto.getCurrentTemperature());
+        HeatingSystem savedHeatingSystem = heatingSystemRepository.save(heatingSystem);
+        return convertToDto(savedHeatingSystem);
+    }
+
     @Override
     public HeatingSystemDto getHeatingSystem(Long id) {
         HeatingSystem heatingSystem = heatingSystemRepository.findById(id)


### PR DESCRIPTION
## Summary
- implement POST /api/heating to create a heating system
- extend service interface with `createHeatingSystem`
- implement creation logic in service implementation

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532317e354832396d6c9424e235b03