### PR TITLE
Add Swagger documentation with springdoc

### DIFF
--- a/smart-home-monolith/README.md
+++ b/smart-home-monolith/README.md
@@ -26,7 +26,7 @@
 - `spring-boot-starter-web` - для создания веб-приложений.
 - `spring-boot-starter-data-jpa` - для работы с JPA и базой данных.
 - `postgresql` - драйвер для работы с PostgreSQL.
-- `springfox-boot-starter` - для интеграции Swagger.
+- `springdoc-openapi-starter-webmvc-ui` - для интеграции Swagger.
 - `lombok` - для упрощения написания кода.
 - `spring-boot-starter-test`, `spring-boot-testcontainers`, `junit-jupiter`, `testcontainers` - для тестирования.
 
@@ -42,6 +42,14 @@ docker run --name postgres-db -e POSTGRES_DB=smart_home -e POSTGRES_USER=your_us
 
 ``` shell
 mvn spring-boot:run
+```
+
+## Swagger UI
+
+После запуска приложение доступна документация Swagger по адресу:
+
+```
+http://localhost:8080/swagger-ui/index.html
 ```
 
 ## Тесты

--- a/smart-home-monolith/pom.xml
+++ b/smart-home-monolith/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <springfox-swagger.version>3.0.0</springfox-swagger.version>
+        <springdoc.version>2.5.0</springdoc.version>
         <lombok.version>1.18.34</lombok.version>
         <testcontainers.version>1.20.1</testcontainers.version>
     </properties>
@@ -41,12 +41,12 @@
             <scope>runtime</scope>
         </dependency>
 
-<!--        &lt;!&ndash; Swagger &ndash;&gt;-->
-<!--        <dependency>-->
-<!--            <groupId>io.springfox</groupId>-->
-<!--            <artifactId>springfox-boot-starter</artifactId>-->
-<!--            <version>${springfox-swagger.version}</version>-->
-<!--        </dependency>-->
+        <!-- Swagger/OpenAPI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
 
         <!-- Lombok -->
         <dependency>

--- a/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/SmartHomeApplication.java
+++ b/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/SmartHomeApplication.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @SpringBootApplication
 @EnableJpaRepositories
 @EnableTransactionManagement
-//@EnableSwagger2
 public class SmartHomeApplication {
     public static void main(String[] args) {
         SpringApplication.run(SmartHomeApplication.class, args);

--- a/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/config/OpenApiConfig.java
+++ b/smart-home-monolith/src/main/java/ru/yandex/practicum/smarthome/config/OpenApiConfig.java
@@ -1,0 +1,10 @@
+package ru.yandex.practicum.smarthome.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "Smart Home API", version = "1.0", description = "API documentation for Smart Home"))
+public class OpenApiConfig {
+}


### PR DESCRIPTION
## Summary
- integrate Swagger UI using springdoc-openapi
- document endpoints with OpenAPI definition
- update dependencies and docs

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534074121c8323b886f3e3d7cb80a0