### PR TITLE
Fix Swagger config path

### DIFF
--- a/smart-home-monolith/pom.xml
+++ b/smart-home-monolith/pom.xml
@@ -55,13 +55,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Servlet API -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/smart-home-monolith/src/main/resources/application.yml
+++ b/smart-home-monolith/src/main/resources/application.yml
@@ -21,3 +21,7 @@ spring:
 
 server:
   port: 8080
+
+springdoc:
+  swagger-ui:
+    config-url: /v3/api-docs


### PR DESCRIPTION
## Summary
- remove javax.servlet-api dependency from the project
- configure swagger-ui config URL so documentation loads correctly

## Testing
- `mvn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685716abe9e88323b71ac9a4e48018fe